### PR TITLE
fix: ensure TokenModal opens immediately after pasting contract address

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -35,6 +35,7 @@ const Navbar = () => {
     const clipboardText = await pasteFromClipboard();
     if (clipboardText) {
       setTokenInput(clipboardText);
+      setIsPasteModalOpen(true); // Open modal immediately after pasting
       toast.success("Successfully pasted from clipboard!");
     }
   };


### PR DESCRIPTION
- Updated handlePaste function to trigger modal opening as soon as the contract address is pasted
- Set isPasteModalOpen to true right after updating tokenInput to avoid delays
- Improved user experience by ensuring modal opens consistently after paste action